### PR TITLE
feat(ui): Basic Task List

### DIFF
--- a/app/ui/lib/main.dart
+++ b/app/ui/lib/main.dart
@@ -1,122 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:ntango/src/features/tasks/presentation/pages/tasks_page.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const NtangoApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class NtangoApp extends StatelessWidget {
+  const NtangoApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Ntango',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        primarySwatch: Colors.blue,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const TasksPage(),
     );
   }
 }

--- a/app/ui/lib/src/features/tasks/data/models/task_model.dart
+++ b/app/ui/lib/src/features/tasks/data/models/task_model.dart
@@ -1,0 +1,19 @@
+
+
+class TaskModel {
+  final String id;
+  final String title;
+  final String description;
+  final DateTime startDate;
+  final DateTime endDate;
+  final bool isCompleted;
+
+  TaskModel({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.startDate,
+    required this.endDate,
+    this.isCompleted = false,
+  });
+}

--- a/app/ui/lib/src/features/tasks/data/repositories/task_repository.dart
+++ b/app/ui/lib/src/features/tasks/data/repositories/task_repository.dart
@@ -3,7 +3,7 @@ import 'package:ntango/src/features/tasks/data/models/task_model.dart';
 
 class TaskRepository {
 
-  Future<List<TaskModel>> getAllTask() async {
+  static Future<List<TaskModel>> getAllTask() async {
     // Mock data
     return [
       TaskModel(

--- a/app/ui/lib/src/features/tasks/data/repositories/task_repository.dart
+++ b/app/ui/lib/src/features/tasks/data/repositories/task_repository.dart
@@ -1,0 +1,36 @@
+
+import 'package:ntango/src/features/tasks/data/models/task_model.dart';
+
+class TaskRepository {
+
+  Future<List<TaskModel>> getAllTask() async {
+    // Mock data
+    return [
+      TaskModel(
+        id: '1',
+        title: 'Task 1',
+        description: 'Description 1',
+        startDate: DateTime.now().add(Duration(hours: 1)),
+        endDate: DateTime.now().add(Duration(hours: 2)),
+        isCompleted: false,
+      ),
+      TaskModel(
+        id: '2',
+        title: 'Task 2',
+        description: 'Description 2',
+        startDate: DateTime.now().add(Duration(hours: 2, minutes: 30)),
+        endDate: DateTime.now().add(Duration(hours: 3)),
+        isCompleted: false,
+      ),
+      TaskModel(
+        id: '3',
+        title: 'Task 3',
+        description: 'Description 3',
+        startDate: DateTime.now().add(Duration(hours: 3, minutes: 30)),
+        endDate: DateTime.now().add(Duration(hours: 4, minutes: 0)),
+        isCompleted: false,
+      ),
+    ];
+  }
+
+}

--- a/app/ui/lib/src/features/tasks/presentation/pages/tasks_page.dart
+++ b/app/ui/lib/src/features/tasks/presentation/pages/tasks_page.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:ntango/src/features/tasks/data/models/task_model.dart';
+import 'package:ntango/src/features/tasks/data/repositories/task_repository.dart';
 import 'package:ntango/src/features/tasks/presentation/widgets/task_card.dart';
 
 class TasksPage extends StatelessWidget {
@@ -8,22 +10,30 @@ class TasksPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Tasks')),
-      body: ListView(
-        children: const [
-          TaskCard(
-            timeRange: '9:00 AM - 10:30 AM',
-            title: 'Project Planning',
-            subtitle: 'High Priority',
-            badgeText: 'Focus Time',
-          ),
-          SizedBox(height: 16),
-          TaskCard(
-            timeRange: '11:00 AM - 12:00 PM',
-            title: 'Daily Exercise',
-            subtitle: 'Streak: 5 days',
-            badgeText: 'Habit',
-          ),
-        ],
+      body: FutureBuilder<List<TaskModel>>(
+        future: TaskRepository.getAllTask(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(
+              child: Text('Error: ${snapshot.error}'),
+            );
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(
+              child: Text('No tasks found'),
+            );
+          } else {
+            final tasks = snapshot.data!;
+            return ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: tasks.length,
+              separatorBuilder: (context, index) =>
+                  const SizedBox(height: 16),
+              itemBuilder: (context, index) => TaskCard(task: tasks[index]),
+            );
+          }
+        },
       ),
     );
   }

--- a/app/ui/lib/src/features/tasks/presentation/pages/tasks_page.dart
+++ b/app/ui/lib/src/features/tasks/presentation/pages/tasks_page.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:ntango/src/features/tasks/presentation/widgets/task_card.dart';
+
+class TasksPage extends StatelessWidget {
+  const TasksPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tasks')),
+      body: ListView(
+        children: const [
+          TaskCard(
+            timeRange: '9:00 AM - 10:30 AM',
+            title: 'Project Planning',
+            subtitle: 'High Priority',
+            badgeText: 'Focus Time',
+          ),
+          SizedBox(height: 16),
+          TaskCard(
+            timeRange: '11:00 AM - 12:00 PM',
+            title: 'Daily Exercise',
+            subtitle: 'Streak: 5 days',
+            badgeText: 'Habit',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/ui/lib/src/features/tasks/presentation/widgets/task_card.dart
+++ b/app/ui/lib/src/features/tasks/presentation/widgets/task_card.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+class TaskCard extends StatelessWidget {
+  final String timeRange;
+  final String title;
+  final String subtitle;
+  final String badgeText;
+
+  const TaskCard({
+    super.key,
+    required this.timeRange,
+    required this.title,
+    required this.subtitle,
+    required this.badgeText,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            /// Top row
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  timeRange,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                _buildBadge(context),
+              ],
+            ),
+            const SizedBox(height: 8),
+            /// Title
+            Text(
+              title,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            /// Subtitle
+            Text(
+              subtitle,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[700],
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBadge(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.grey[200],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        badgeText,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: Colors.black54,
+            ),
+      ),
+    );
+  }
+}

--- a/app/ui/lib/src/features/tasks/presentation/widgets/task_card.dart
+++ b/app/ui/lib/src/features/tasks/presentation/widgets/task_card.dart
@@ -4,10 +4,12 @@ import 'package:ntango/src/features/tasks/data/models/task_model.dart';
 
 class TaskCard extends StatelessWidget {
   final TaskModel task;
+  final VoidCallback? onTap; // Optional tap callback
 
   const TaskCard({
     super.key,
     required this.task,
+    this.onTap,
   });
 
   String _formatTimeRange() {
@@ -16,70 +18,82 @@ class TaskCard extends StatelessWidget {
   }
 
   String get badgeText {
-    // Example logic: if the task is completed then show 'Completed', else 'Pending'
-    return task.isCompleted ? 'Completed' : 'Pending';
+    if (task.isCompleted) {
+      return 'Completed';
+    } else if (DateTime.now().isAfter(task.startDate) &&
+        DateTime.now().isBefore(task.endDate)) {
+      return 'In Progress';
+    } else {
+      return 'Pending';
+    }
+  }
+
+  Color _badgeColor(BuildContext context) {
+    if (task.isCompleted) {
+      return Theme.of(context).colorScheme.secondaryContainer;
+    } else if (DateTime.now().isAfter(task.startDate) &&
+        DateTime.now().isBefore(task.endDate)) {
+      return Colors.amber;
+    } else {
+      return Theme.of(context).colorScheme.primaryContainer;
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     return Card(
+      elevation: 3,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
       ),
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Top row
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(
-                  _formatTimeRange(),
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
-                ),
-                _buildBadge(context),
-              ],
-            ),
-            const SizedBox(height: 8),
-            // Title
-            Text(
-              task.title,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Top row with time range and badge
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    _formatTimeRange(),
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
                   ),
-            ),
-            const SizedBox(height: 4),
-            // Subtitle (using task description)
-            Text(
-              task.description,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Colors.grey[700],
-                  ),
-            ),
-          ],
+                  Chip(
+                    label: Text(
+                      badgeText,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                    backgroundColor: _badgeColor(context),
+                  )
+                ],
+              ),
+              const SizedBox(height: 8),
+              // Task title
+              Text(
+                task.title,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 4),
+              // Task description
+              Text(
+                task.description,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Colors.grey[700],
+                    ),
+              ),
+            ],
+          ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildBadge(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: Colors.grey[200],
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Text(
-        badgeText,
-        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              fontWeight: FontWeight.w600,
-              color: Colors.black54,
-            ),
       ),
     );
   }

--- a/app/ui/lib/src/features/tasks/presentation/widgets/task_card.dart
+++ b/app/ui/lib/src/features/tasks/presentation/widgets/task_card.dart
@@ -1,18 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:ntango/src/features/tasks/data/models/task_model.dart';
 
 class TaskCard extends StatelessWidget {
-  final String timeRange;
-  final String title;
-  final String subtitle;
-  final String badgeText;
+  final TaskModel task;
 
   const TaskCard({
     super.key,
-    required this.timeRange,
-    required this.title,
-    required this.subtitle,
-    required this.badgeText,
+    required this.task,
   });
+
+  String _formatTimeRange() {
+    final timeFormat = DateFormat.jm();
+    return '${timeFormat.format(task.startDate)} - ${timeFormat.format(task.endDate)}';
+  }
+
+  String get badgeText {
+    // Example logic: if the task is completed then show 'Completed', else 'Pending'
+    return task.isCompleted ? 'Completed' : 'Pending';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -26,12 +32,12 @@ class TaskCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            /// Top row
+            // Top row
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  timeRange,
+                  _formatTimeRange(),
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         fontWeight: FontWeight.w600,
                       ),
@@ -40,17 +46,17 @@ class TaskCard extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 8),
-            /// Title
+            // Title
             Text(
-              title,
+              task.title,
               style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
             ),
             const SizedBox(height: 4),
-            /// Subtitle
+            // Subtitle (using task description)
             Text(
-              subtitle,
+              task.description,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Colors.grey[700],
                   ),

--- a/app/ui/pubspec.lock
+++ b/app/ui/pubspec.lock
@@ -75,6 +75,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   leak_tracker:
     dependency: transitive
     description:

--- a/app/ui/pubspec.yaml
+++ b/app/ui/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:

--- a/app/ui/test/widget_test.dart
+++ b/app/ui/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:ui/main.dart';
+import 'package:ntango/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/app/ui/test/widget_test.dart
+++ b/app/ui/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:ntango/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const NtangoApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
This pull request introduces significant changes to the `app/ui` module, primarily focusing on the implementation of a task management feature. The most important changes include the creation of new models, repositories, and UI components for tasks, as well as updates to the main application entry point.

### Task Management Feature:

* **Task Model:**
  * Added `TaskModel` class to represent a task with properties such as `id`, `title`, `description`, `startDate`, `endDate`, and `isCompleted`.

* **Task Repository:**
  * Added `TaskRepository` class with a static method `getAllTask` to provide mock data for tasks.

* **Task Page:**
  * Created `TasksPage` widget to display a list of tasks using `FutureBuilder` and `TaskRepository`.

* **Task Card:**
  * Added `TaskCard` widget to display individual task details, including title, description, and status badge.

### Application Updates:

* **Main Entry Point:**
  * Updated `main.dart` to rename the main application widget from `MyApp` to `NtangoApp` and set the home page to `TasksPage`.
  * Updated `pubspec.yaml` to include the `intl` package for date formatting.
  * Updated `widget_test.dart` to reflect the changes in the main application widget name.